### PR TITLE
Fix model name to use gpt-3.5-16k

### DIFF
--- a/chapter_10.py
+++ b/chapter_10.py
@@ -31,7 +31,7 @@ def select_model():
     model = st.sidebar.radio("Choose a model:", ("GPT-3.5", "GPT-3.5-16k", "GPT-4"))
     if model == "GPT-3.5":
         st.session_state.model_name = "gpt-3.5-turbo"
-    elif model == "GPT-3.5":
+    elif model == "GPT-3.5-16k":
         st.session_state.model_name = "gpt-3.5-turbo-16k"
     else:
         st.session_state.model_name = "gpt-4"


### PR DESCRIPTION
本読ませていただきました。わかりやすかったです、ありがとうございます。

gpt-3.5-16k が使われていなさそうな箇所があったので修正PRです。
本のChapter8, 10のコードも同じような修正が必要かもしれません。

 - https://zenn.dev/ml_bear/books/d1f060a3f166a5/viewer/9f3e99
 - https://zenn.dev/ml_bear/books/d1f060a3f166a5/viewer/e6d707